### PR TITLE
docs: fix json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Create the file `config.json` in your working directory:
 ```json
 {
     "email": "email@example.org",
-    "password": "xxx",
+    "password": "xxx"
 }
 ```
 


### PR DESCRIPTION
just remove a extra comma

<img width="686" alt="image" src="https://user-images.githubusercontent.com/71683364/209129448-cc3887bb-9670-45b3-a147-cf456f419f05.png">
